### PR TITLE
Fix: Correct an issue related to clearing the Faiss index in Flask4ModelCache_demo

### DIFF
--- a/modelcache/manager/vector_data/faiss.py
+++ b/modelcache/manager/vector_data/faiss.py
@@ -34,7 +34,10 @@ class Faiss(VectorBase):
         return list(zip(dist[0], ids))
 
     def rebuild_col(self, ids=None):
-        return True
+        try:
+            self._index.reset()
+        except Exception as e:
+            return f"An error occurred during index rebuild: {e}"
 
     def rebuild(self, ids=None):
         return True


### PR DESCRIPTION
Fixed an issue where clearing faiss database was invalid when using flask4modelcache_demo.py

When I run flask4modelcache_demo.py, I found that the Cache-Clearing method mentioned in the documentation cannot clear the Faiss index and returns an error message. Upon inspecting the code, I discovered that this logic was not implemented. Therefore, this pull request adds a method to reset the index.

Additionally, I noticed that rebuild_col() only works properly when it has no return value. I'm unsure if this is intended behavior, so I made minimal changes to achieve the desired functionality without altering it.

I'm honored to be involved in your open-source project. Please feel free to contact me if there are any issues with my changes. I'm very eager to join the open-source initiative of CodeFuse AI!