### PR TITLE
Fix cache eviction and soft deleted using MySQL and Milvus

### DIFF
--- a/modelcache/manager/eviction_manager.py
+++ b/modelcache/manager/eviction_manager.py
@@ -29,10 +29,10 @@ class EvictionManager:
             return True
         return False
 
-    def delete(self):
+    def delete(self,model):
         mark_ids = self._scalar_storage.get_ids(deleted=True)
         self._scalar_storage.clear_deleted_data()
-        self._vector_base.delete(mark_ids)
+        self._vector_base.delete(mark_ids,model)
         self.delete_count += 1
         if self.delete_count >= self.REBUILD_CONDITION:
             self.rebuild()

--- a/modelcache/manager/scalar_data/sql_storage.py
+++ b/modelcache/manager/scalar_data/sql_storage.py
@@ -127,7 +127,7 @@ class SQLStorage(CacheStorage):
             conn.close()
 
     def get_ids(self, deleted=True):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         state = 1 if deleted else 0
         query_sql = "Select id FROM {} WHERE is_deleted = {}".format(table_name, state)
         
@@ -142,7 +142,7 @@ class SQLStorage(CacheStorage):
         return ids
 
     def mark_deleted(self, keys):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         mark_sql = " update {} set is_deleted=1 WHERE id in ({})".format(table_name, ",".join([str(i) for i in keys]))
 
         # 从连接池中获取连接
@@ -159,7 +159,7 @@ class SQLStorage(CacheStorage):
         return delete_count
 
     def model_deleted(self, model_name):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         delete_sql = "Delete from {} WHERE model='{}'".format(table_name, model_name)
 
         table_log_name = "modelcache_query_log"
@@ -181,7 +181,7 @@ class SQLStorage(CacheStorage):
         return resp
 
     def clear_deleted_data(self):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         delete_sql = "DELETE FROM {} WHERE is_deleted = 1".format(table_name)
         
         conn = self.pool.connection()
@@ -196,7 +196,7 @@ class SQLStorage(CacheStorage):
         return delete_count
 
     def count(self, state: int = 0, is_all: bool = False):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         if is_all:
             count_sql = "SELECT COUNT(*) FROM {}".format(table_name)
         else:

--- a/modelcache/manager/scalar_data/sql_storage.py
+++ b/modelcache/manager/scalar_data/sql_storage.py
@@ -43,7 +43,7 @@ class SQLStorage(CacheStorage):
         embedding_data = embedding_data.tobytes()
         is_deleted = 0
 
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         insert_sql = "INSERT INTO {} (question, answer, answer_type, model, embedding_data, is_deleted) VALUES (%s, %s, %s, %s, _binary%s, %s)".format(table_name)
         conn = self.pool.connection()
         try:
@@ -91,7 +91,7 @@ class SQLStorage(CacheStorage):
             conn.close()
 
     def get_data_by_id(self, key: int):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         query_sql = "select question, answer, embedding_data, model from {} where id={}".format(table_name, key)
         conn_start = time.time()
         conn = self.pool.connection()
@@ -112,7 +112,7 @@ class SQLStorage(CacheStorage):
             return None
 
     def update_hit_count_by_id(self, primary_id: int):
-        table_name = "cache_codegpt_answer"
+        table_name = "modelcache_llm_answer"
         update_sql = "UPDATE {} SET hit_count = hit_count+1 WHERE id={}".format(table_name, primary_id)
         conn = self.pool.connection()
 

--- a/reference_doc/create_table.sql
+++ b/reference_doc/create_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `cache_codegpt_answer` (
+CREATE TABLE `modelcache_llm_answer` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT comment '主键',
   `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP comment '创建时间',
   `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP comment '修改时间',

--- a/reference_doc/create_table.sql
+++ b/reference_doc/create_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `modelcache_llm_answer` (
+CREATE TABLE `cache_codegpt_answer` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT comment '主键',
   `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP comment '创建时间',
   `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP comment '修改时间',
@@ -8,8 +8,9 @@ CREATE TABLE `modelcache_llm_answer` (
   `hit_count` int(11) NOT NULL DEFAULT '0' comment 'hit_count',
   `model` varchar(1000) NOT NULL comment 'model',
   `embedding_data` blob NOT NULL comment 'embedding_data',
+  `is_deleted` tinyint(1) NOT NULL DEFAULT '0' COMMENT 'delete state(0 Not deleted,-1 deleted)',
   PRIMARY KEY(`id`)
-) AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COMMENT = 'modelcache_llm_answer';
+) AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COMMENT = 'cache_codegpt_answer';
 
 
 CREATE TABLE `modelcache_query_log` (


### PR DESCRIPTION

**Abstract:**
1. Implemented soft delete and hard delete in MySQL.
2. Implemented a cache eviction strategy using MySQL and Milvus.

**Problems Solved:**
1. Multiple methods were not implemented, causing issues when applying the cache eviction strategy.
2. The `mark_deleted` method did not perform a soft delete but instead directly deleted the data by `mark_id`.
3. The `cache_codegpt_answer` table in the database did not have an `is_deleted` field, making soft deletes impossible.
4. The table creation statement you provided was only applicable to SQLite for `modelcache_llm_answer`, while MySQL used the `cache_codegpt_answer` table.
5. The `self._vector_base.delete` method did not specify a model, making it impossible to delete the corresponding table during cache eviction.

**Modifications:**
1. Implemented true soft delete:
   - Renamed and added fields to the table in the database.
   - In `modelcache\manager\scalar_data\sql_storage.py`:
     - Implemented the `mark_deleted` method to mark the `is_deleted` field as 1 (pending deletion).
     - Implemented the `clear_deleted_data` method.
     - Implemented the `count` method.

2. Database modifications:
   - (1) Renamed the table in `reference_doc\create_table.sql` from `modelcache_llm_answer` to `cache_codegpt_answer`, or alternatively modified the `table_name` in the code.
   - (2) Added the `is_deleted` field to `cache_codegpt_answer`, with -1 for pending deletion and 0 for not deleted (consistent with GPTCache).

3. Implemented the cache eviction strategy, defaulting to LRU:
   - In `modelcache\manager\eviction_manager.py`, added a `model` parameter to the `delete` method to enable deletion of corresponding IDs in Milvus.

Considering that I only implemented the method for MySQL, I did not directly apply the cache eviction strategy in `data_manager.py`. To use the cache eviction strategy (MySQL + Milvus), you need to add the following in `modelcache\manager\data_manager.py`:

```python
class SSDataManager(DataManager):
    def __init__(
        self,
        s: CacheStorage,
        v: VectorBase,
        o: Optional[ObjectBase],
        e: Optional[EvictionBase],
        max_size,
        clean_size,
        policy="LRU",
    ):
        self.max_size = max_size
        self.clean_size = clean_size
        self.s = s
        self.v = v
        self.o = o
        self.eviction_manager = EvictionManager(self.s, self.v)
        if e is None:
            e = EvictionBase(name="memory",
                             maxsize=max_size,
                             clean_size=clean_size,
                             policy=policy,
                             on_evict=self._clear)
        self.eviction_base = e
        self.model = None

    def _clear(self, marked_keys):
        self.eviction_manager.soft_evict(marked_keys)
        # Soft delete
        if self.eviction_manager.check_evict():
            self.eviction_manager.delete(self.model)

    def save(self, system_sentence, sys_embedding_data, question, answer, embedding_data, **kwargs):
        self.model = kwargs.pop("model", None)
        self.import_data([system_sentence], [sys_embedding_data], [question], [answer], [embedding_data], self.model)
```

The definition of `self.model` is to inform the data manager which model's table is being processed during insertion. The code refers to gptcache and tries to be functionally consistent.

This method has been locally verified to be feasible, with both the eviction strategy and soft delete functioning properly.

 Please feel free to contact me if there are any issues with my changes.